### PR TITLE
Bad CMakeLists for catkin metapackage

### DIFF
--- a/rbot/CMakeLists.txt
+++ b/rbot/CMakeLists.txt
@@ -1,18 +1,4 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rbot)
-
-## Find catkin macros and libraries
 find_package(catkin REQUIRED)
-catkin_metapacakge()
-
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if your package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
-catkin_package(
-#  INCLUDE_DIRS include
-#  LIBRARIES rbot
-#  CATKIN_DEPENDS other_catkin_pkg
-#  DEPENDS system_lib
-)
+catkin_metapackage()


### PR DESCRIPTION
Catkin metapackage requires a specific CMakeLists. If it slightly diverges from it, it will be treated as a non-catkin package, forcing an isolated build.
c.f. [http://wiki.ros.org/catkin/package.xml#Metapackages](http://wiki.ros.org/catkin/package.xml#Metapackages)

This PR restores the boilerplate CMakeLists.